### PR TITLE
Fixes for rust nightly-2021-07-21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,3 @@ name = "r1cs"
 harness = false
 required-features = ["yoloproofs", "avx2_backend"]
 
-[patch.crates-io]
-# Fixes for nightly-2021-07-21
-curve25519-dalek = { git = "https://github.com/jcape/curve25519-dalek.git", rev = "46d07765b228d43fe910eb6a1769143f8fc366bb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,13 @@ clear_on_drop = { version = "0.2", default-features = false }
 hex = "0.3"
 criterion = "0.3"
 bincode = "1"
-rand_chacha = "0.2"
+rand_chacha = "0.3"
 
 [features]
 default = ["std"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["rand", "rand/std", "thiserror", "curve25519-dalek/std"]
+std = ["rand", "rand/std", "rand/std_rng", "thiserror", "curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "bulletproofs"
+name = "bulletproofs-og"
 # Before doing a release:
-# - update version field 
+# - update version field
 # - update html_root_url
 # - ensure yoloproofs was disabled in an atomic (revertable) commit
 # - update CHANGELOG
-version = "2.0.0"
-authors = ["Cathie Yun <cathieyun@gmail.com>", 
+version = "3.0.0-pre.0"
+authors = ["Cathie Yun <cathieyun@gmail.com>",
            "Henry de Valence <hdevalence@hdevalence.ca>",
            "Oleg Andreev <oleganza@gmail.com>"]
 readme = "README.md"
@@ -18,17 +18,17 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { version = "3", default-features = false, features = ["u64_backend", "serde"] }
+curve25519-dalek = { version = "4.0.0-pre.1", default-features = false, features = ["u64_backend", "serde"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 digest = { version = "0.9.0", default-features = false }
-rand_core = { version = "0.5", default-features = false, features = ["alloc"] }
-rand = { version = "0.7", default-features = false, optional = true }
+rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
+rand = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
-merlin = { version = "2", default-features = false }
+merlin = { version = "3", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 
 [dev-dependencies]
@@ -66,3 +66,7 @@ harness = false
 name = "r1cs"
 harness = false
 required-features = ["yoloproofs", "avx2_backend"]
+
+[patch.crates-io]
+# Fixes for nightly-2021-07-21
+curve25519-dalek = { git = "https://github.com/jcape/curve25519-dalek.git", rev = "46d07765b228d43fe910eb6a1769143f8fc366bb" }

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -175,7 +175,7 @@ fn bench_kshuffle_prove(c: &mut Criterion) {
             let mut rng = rand::thread_rng();
             let (min, max) = (0u64, std::u64::MAX);
             let input: Vec<Scalar> = (0..*k)
-                .map(|_| Scalar::from(rng.gen_range(min, max)))
+                .map(|_| Scalar::from(rng.gen_range(min..max)))
                 .collect();
             let mut output = input.clone();
             output.shuffle(&mut rand::thread_rng());
@@ -217,7 +217,7 @@ fn bench_kshuffle_verify(c: &mut Criterion) {
                 let mut rng = rand::thread_rng();
                 let (min, max) = (0u64, std::u64::MAX);
                 let input: Vec<Scalar> = (0..*k)
-                    .map(|_| Scalar::from(rng.gen_range(min, max)))
+                    .map(|_| Scalar::from(rng.gen_range(min..max)))
                     .collect();
                 let mut output = input.clone();
                 output.shuffle(&mut rand::thread_rng());

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -26,7 +26,7 @@ fn create_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             let mut rng = rand::thread_rng();
 
             let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
-            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
             let blindings: Vec<Scalar> = (0..m).map(|_| Scalar::random(&mut rng)).collect();
 
             b.iter(|| {
@@ -74,7 +74,7 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             let mut rng = rand::thread_rng();
 
             let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
-            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
             let blindings: Vec<Scalar> = (0..m).map(|_| Scalar::random(&mut rng)).collect();
 
             let mut transcript = Transcript::new(b"AggregateRangeProofBenchmark");

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -338,6 +338,8 @@ impl InnerProductProof {
     /// The layout of the inner product proof is:
     /// * \\(n\\) pairs of compressed Ristretto points \\(L_0, R_0 \dots, L_{n-1}, R_{n-1}\\),
     /// * two scalars \\(a, b\\).
+    // FIXME: find the real combination of features which cause this to be invoked.
+    #[allow(dead_code)]
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_size());
         for (l, r) in self.L_vec.iter().zip(self.R_vec.iter()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "docs", feature(external_doc))]
 #![cfg_attr(feature = "docs", deny(missing_docs))]
 #![cfg_attr(feature = "docs", doc(include = "../README.md"))]
 #![cfg_attr(

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -156,7 +156,7 @@ fn kshuffle_helper(k: usize) {
         let mut rng = rand::thread_rng();
         let (min, max) = (0u64, std::u64::MAX);
         let input: Vec<Scalar> = (0..k)
-            .map(|_| Scalar::from(rng.gen_range(min, max)))
+            .map(|_| Scalar::from(rng.gen_range(min..max)))
             .collect();
         let mut output = input.clone();
         output.shuffle(&mut rand::thread_rng());
@@ -411,7 +411,7 @@ fn range_proof_gadget() {
 
     for n in [2, 10, 32, 63].iter() {
         let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
-        let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+        let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
         for v in values {
             assert!(range_proof_helper(v.into(), *n).is_ok());
         }


### PR DESCRIPTION
Patches for bulletproofs to support running under current nightly, and rename the crate to "bulletproofs-og".