### PR TITLE
make curve25519-dalek/u64_backend optional for non 64-bit platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,14 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["u64_backend", "serde"] }
+curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = [ "alloc" ] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 digest = "0.10"
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
-serde = { version = "1", default-features = false, features = ["alloc"] }
-serde_derive = { version = "1", default-features = false }
+serde = { version = "1", optional = true, default-features = false, features = ["alloc", "derive"] }
 thiserror = { version = "1", optional = true }
 merlin = { version = "3", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
@@ -38,9 +37,11 @@ bincode = "1"
 rand_chacha = "0.3"
 
 [features]
-default = ["std"]
+default = ["std", "u64_backend", "serde"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
+u64_backend = ["curve25519-dalek/u64_backend"]
 yoloproofs = []
+serde = ["dep:serde", "curve25519-dalek/serde"]
 std = ["rand", "rand/std", "rand/std_rng", "thiserror", "curve25519-dalek/std", "digest/std"]
 nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 
 extern crate alloc;
 
-#[macro_use]
-extern crate serde_derive;
 
 mod util;
 

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -204,6 +204,7 @@ impl R1CSProof {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for R1CSProof {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -213,6 +214,7 @@ impl Serialize for R1CSProof {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for R1CSProof {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -13,8 +13,12 @@ use curve25519_dalek::scalar::Scalar;
 
 use crate::generators::{BulletproofGens, PedersenGens};
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// A commitment to the bits of a party's value.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BitCommitment {
     pub(super) V_j: CompressedRistretto,
     pub(super) A_j: RistrettoPoint,
@@ -22,28 +26,32 @@ pub struct BitCommitment {
 }
 
 /// Challenge values derived from all parties' [`BitCommitment`]s.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BitChallenge {
     pub(super) y: Scalar,
     pub(super) z: Scalar,
 }
 
 /// A commitment to a party's polynomial coefficents.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PolyCommitment {
     pub(super) T_1_j: RistrettoPoint,
     pub(super) T_2_j: RistrettoPoint,
 }
 
 /// Challenge values derived from all parties' [`PolyCommitment`]s.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PolyChallenge {
     pub(super) x: Scalar,
 }
 
 /// A party's proof share, ready for aggregation into the final
 /// [`RangeProof`](::RangeProof).
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProofShare {
     pub(super) t_x: Scalar,
     pub(super) t_x_blinding: Scalar,

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -23,8 +23,12 @@ use crate::transcript::TranscriptProtocol;
 use crate::util;
 
 use rand_core::{CryptoRng, RngCore};
-use serde::de::Visitor;
-use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(feature = "serde")]
+use serde::{
+    self, Deserialize, Deserializer, Serialize, Serializer,
+    de::Visitor,
+};
 
 // Modules for MPC protocol
 
@@ -538,6 +542,7 @@ impl RangeProof {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for RangeProof {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -546,7 +551,7 @@ impl Serialize for RangeProof {
         serializer.serialize_bytes(&self.to_bytes()[..])
     }
 }
-
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for RangeProof {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
also gates serde behind `serde` feature to aid in no_std use (though it seems `alloc` is always required)